### PR TITLE
Fix dark mode button contrast

### DIFF
--- a/src/app/App.css
+++ b/src/app/App.css
@@ -109,6 +109,7 @@ html {
   --bg-tertiary: var(--gray-100);
   --bg-muted: var(--gray-200);
   --bg-disabled: var(--gray-100);
+  --bg-hover: var(--gray-50);
   
   /* === COLORES DE TEXTO === */
   --text-primary: var(--gray-900);
@@ -290,6 +291,7 @@ html {
   --bg-tertiary: var(--gray-700);
   --bg-muted: var(--gray-600);
   --bg-disabled: var(--gray-800);
+  --bg-hover: var(--gray-800);
   
   --text-primary: var(--gray-50);
   --text-secondary: var(--gray-300);

--- a/src/components/atoms/Button/Button.css
+++ b/src/components/atoms/Button/Button.css
@@ -14,6 +14,7 @@
     font-weight: var(--font-weight-medium);
     text-decoration: none;
     white-space: nowrap;
+    color: var(--text-primary);
     
     /* Interacción */
     cursor: pointer;


### PR DESCRIPTION
## Summary
- add missing `--bg-hover` CSS variable for light/dark themes
- set default text color for buttons to use design system variable

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-storybook')*

------
https://chatgpt.com/codex/tasks/task_e_685e971793b88330b09bbd0ded736863