### PR TITLE
Add movie navigation utilities and refactor ContentCard

### DIFF
--- a/src/Pages/MainPage/MainPage.jsx
+++ b/src/Pages/MainPage/MainPage.jsx
@@ -3,6 +3,8 @@
 
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useMovieNavigation } from '../../hooks/useMovieNavigation';
+import { transformMovieData } from '../../utils/movieDataTransformer';
 import { Button } from '../../components/atoms/Button/Button';
 import { PageLayout } from '../../components/templates/PageLayout/PageLayout';
 import { AppHeader } from '../../components/organism/AppHeader/AppHeader';
@@ -21,6 +23,7 @@ import { getCategoriesService } from '../../services/Categories/getCategoriesSer
 
 function MainPage() {
     const navigate = useNavigate();
+    const { navigateToPlayer, navigateToDetails } = useMovieNavigation();
     
     // Estados
     const [searchTerm, setSearchTerm] = useState('');
@@ -138,10 +141,18 @@ function MainPage() {
     };
 
     /**
-     * Manejar reproducción de contenido
+     * Manejar reproducción de película o serie
      */
-    const handlePlayContent = (content) => {
-        navigate(`/player/${content.id}`);
+    const handlePlayMovie = (content) => {
+        navigateToPlayer(content);
+    };
+
+    const handleMovieClick = (content) => {
+        navigateToDetails(content);
+    };
+
+    const handleFavoriteMovie = (content) => {
+        console.log('Favorito:', content.title);
     };
 
     /**
@@ -171,17 +182,9 @@ function MainPage() {
             console.log('🎬 Respuesta movies:', response); // Debug
             
             const movieData = Array.isArray(response) ? response : response?.data || [];
-            const mappedMovies = movieData.map(movie => ({
-                id: movie.id,
-                title: movie.title,
-                category: movie.category || 'Sin categoría', // Para mostrar
-                categoryId: movie.categoryId, // Para filtrar
-                year: movie.releaseYear || movie.year || new Date().getFullYear(),
-                cover: `http://localhost:8082/covers/${movie.cover_image}/cover.jpg`,
-                type: 'movie',
-                rating: movie.rating || 0,
-                duration: movie.duration || 0
-            }));
+            const mappedMovies = movieData.map((movie) =>
+                transformMovieData(movie, categories)
+            );
             
             console.log('🎬 Movies mapeadas:', mappedMovies); // Debug
             setMovies(mappedMovies);
@@ -405,8 +408,9 @@ function MainPage() {
                     <ContentCard
                         key={`movie-${movie.id}`}
                         content={movie}
-                        onClick={() => handlePlayContent(movie)}
-                        onFavoriteClick={() => console.log('Favorito:', movie.title)}
+                        onPlay={() => handlePlayMovie(movie)}
+                        onClick={() => handleMovieClick(movie)}
+                        onFavorite={() => handleFavoriteMovie(movie)}
                         size="md"
                         showRating={true}
                         variant="elevated"
@@ -461,8 +465,9 @@ function MainPage() {
                     <ContentCard
                         key={`series-${serie.id}`}
                         content={serie}
-                        onClick={() => handlePlayContent(serie)}
-                        onFavoriteClick={() => console.log('Favorito:', serie.title)}
+                        onPlay={() => handlePlayMovie(serie)}
+                        onClick={() => handleMovieClick(serie)}
+                        onFavorite={() => handleFavoriteMovie(serie)}
                         size="md"
                         showRating={true}
                         variant="elevated"

--- a/src/components/molecules/ContentCard/ContentCard.jsx
+++ b/src/components/molecules/ContentCard/ContentCard.jsx
@@ -72,12 +72,7 @@ const ContentCard = ({
 
   // ✅ FILTRAR PROPS PERSONALIZADAS QUE NO DEBEN IR AL DOM
   const {
-    // Props personalizadas que causan el error
-    onFavoriteClick, // ← FILTRAR ESTA PROP
-    onPlayClick,     // ← FILTRAR ESTA PROP
-    contentType,     // ← FILTRAR ESTA PROP
-    
-    // Otros props personalizados que podrían venir del padre
+    // Props personalizados que podrían venir del padre
     content: _content,
     size: _size,
     onPlay: _onPlay,

--- a/src/hooks/useMovieNavigation.js
+++ b/src/hooks/useMovieNavigation.js
@@ -1,0 +1,36 @@
+// src/hooks/useMovieNavigation.js
+import { useNavigate } from 'react-router-dom';
+
+function formatResolutions(resolutions = []) {
+  return resolutions
+    .map((r) => Math.round(r / 10))
+    .sort((a, b) => a - b)
+    .join(',');
+}
+
+function useMovieNavigation() {
+  const navigate = useNavigate();
+
+  const buildPlayerParams = (movieData) => {
+    const original = movieData?._original || movieData;
+    const fileHash = original.file_hash;
+    const formatted = formatResolutions(original.available_resolutions);
+    return { path: `/player/${fileHash}`, search: `resolutions=${formatted}` };
+  };
+
+  const navigateToPlayer = (movieData) => {
+    const { path, search } = buildPlayerParams(movieData);
+    const url = `${path}?${search}`;
+    console.log('[useMovieNavigation] to player:', url);
+    navigate(url);
+  };
+
+  const navigateToDetails = (movieData) => {
+    console.log('[useMovieNavigation] to details:', movieData.id);
+    navigate(`/movies/${movieData.id}`);
+  };
+
+  return { buildPlayerParams, navigateToPlayer, navigateToDetails };
+}
+
+export { useMovieNavigation };

--- a/src/utils/movieDataTransformer.js
+++ b/src/utils/movieDataTransformer.js
@@ -1,0 +1,54 @@
+// src/utils/movieDataTransformer.js
+
+/**
+ * Construir URL de portada a partir del hash entregado por el backend
+ * @param {Object} movieData - Datos de película desde backend
+ * @param {string} baseUrl - URL base del backend
+ * @returns {string} URL completa de la portada
+ */
+function buildCoverUrl(movieData, baseUrl = 'http://localhost:8082') {
+  if (!movieData || !movieData.cover_image) return '';
+  const sanitized = baseUrl.replace(/\/$/, '');
+  return `${sanitized}/covers/${movieData.cover_image}/cover.jpg`;
+}
+
+/**
+ * Transformar los datos de película recibidos del backend al formato utilizado
+ * por los componentes de presentación.
+ * Mantiene los datos originales en la propiedad `_original`.
+ * @param {Object} backendMovie - Película devuelta por el backend
+ * @param {Array|Object} [categoryData] - Datos de categorías para obtener nombre
+ * @param {string} [baseUrl] - URL base para imágenes de portada
+ * @returns {Object} Película transformada
+ */
+function transformMovieData(backendMovie, categoryData = [], baseUrl) {
+  if (!backendMovie) return null;
+
+  const movie = {
+    id: backendMovie.id,
+    title: backendMovie.title,
+    year: backendMovie.release_year || backendMovie.year,
+    categoryId: backendMovie.category_id,
+    category: undefined,
+    cover: buildCoverUrl(backendMovie, baseUrl),
+    type: 'movie',
+    rating: backendMovie.rating,
+    duration: backendMovie.duration,
+    seasons: backendMovie.seasons,
+    episodes: backendMovie.episodes,
+    _original: backendMovie,
+  };
+
+  if (categoryData) {
+    if (Array.isArray(categoryData)) {
+      const found = categoryData.find((c) => String(c.id) === String(backendMovie.category_id));
+      movie.category = found?.label || found?.name;
+    } else if (typeof categoryData === 'object') {
+      movie.category = categoryData[backendMovie.category_id];
+    }
+  }
+
+  return movie;
+}
+
+export { transformMovieData, buildCoverUrl };


### PR DESCRIPTION
## Summary
- create `movieDataTransformer` utility to map backend movie data
- create `useMovieNavigation` hook with reusable navigation helpers
- make `ContentCard` agnostic about routing and remove extra props
- update `MainPage` to use new utilities and callbacks

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-storybook')*

------
https://chatgpt.com/codex/tasks/task_e_6864868705dc833086403f1c97232851