### PR TITLE
Add multi-palette theme system

### DIFF
--- a/src/app/App.css
+++ b/src/app/App.css
@@ -583,3 +583,67 @@ body {
     display: none;
   }
 }
+/* ===== PALETAS DE COLORES PERSONALIZADAS ===== */
+:root {
+  --ocean-primary: #0ea5e9;
+  --ocean-secondary: #10b981;
+  --forest-primary: #84cc16;
+  --forest-secondary: #ea9d47;
+  --sunset-primary: #f97316;
+  --sunset-secondary: #ec4899;
+  --purple-primary: #a855f7;
+  --purple-secondary: #6366f1;
+}
+
+.palette-ocean {
+  --color-primary: var(--ocean-primary);
+  --color-primary-hover: var(--blue-600);
+  --color-secondary: var(--ocean-secondary);
+  --color-secondary-hover: var(--green-600);
+  transition: background-color var(--transition-normal), color var(--transition-normal);
+}
+
+.palette-ocean.dark {
+  --color-primary-light: var(--blue-900);
+  --color-secondary-light: var(--green-900);
+}
+
+.palette-forest {
+  --color-primary: var(--forest-primary);
+  --color-primary-hover: var(--green-600);
+  --color-secondary: var(--forest-secondary);
+  --color-secondary-hover: var(--yellow-700);
+  transition: background-color var(--transition-normal), color var(--transition-normal);
+}
+
+.palette-forest.dark {
+  --color-primary-light: var(--green-900);
+  --color-secondary-light: var(--yellow-900);
+}
+
+.palette-sunset {
+  --color-primary: var(--sunset-primary);
+  --color-primary-hover: var(--orange-600, var(--sunset-primary));
+  --color-secondary: var(--sunset-secondary);
+  --color-secondary-hover: var(--pink-600, var(--sunset-secondary));
+  transition: background-color var(--transition-normal), color var(--transition-normal);
+}
+
+.palette-sunset.dark {
+  --color-primary-light: var(--orange-900, var(--sunset-primary));
+  --color-secondary-light: var(--pink-900, var(--sunset-secondary));
+}
+
+.palette-purple {
+  --color-primary: var(--purple-primary);
+  --color-primary-hover: var(--purple-600, var(--purple-primary));
+  --color-secondary: var(--purple-secondary);
+  --color-secondary-hover: var(--indigo-600, var(--purple-secondary));
+  transition: background-color var(--transition-normal), color var(--transition-normal);
+}
+
+.palette-purple.dark {
+  --color-primary-light: var(--purple-900, var(--purple-primary));
+  --color-secondary-light: var(--indigo-900, var(--purple-secondary));
+}
+

--- a/src/app/context/ThemeContext.jsx
+++ b/src/app/context/ThemeContext.jsx
@@ -2,43 +2,87 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 
 const ThemeContext = createContext();
 
+const AVAILABLE_THEMES = [
+  'light',
+  'dark',
+  'ocean-light',
+  'ocean-dark',
+  'forest-light',
+  'forest-dark',
+  'sunset-light',
+  'sunset-dark',
+  'purple-light',
+  'purple-dark'
+];
+
 function ThemeProvider({ children }) {
-  const [theme, setTheme] = useState('light');
+  const [palette, setPalette] = useState('default');
+  const [mode, setMode] = useState('light');
 
   useEffect(() => {
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      setTheme(savedTheme);
-      applyTheme(savedTheme);
-    } else {
-      applyTheme(theme);
-    }
+    const storedPalette = localStorage.getItem('palette');
+    const storedMode = localStorage.getItem('mode');
+    if (storedPalette) setPalette(storedPalette);
+    if (storedMode) setMode(storedMode);
   }, []);
 
-  const applyTheme = (themeValue) => {
+  useEffect(() => {
+    applyTheme(palette, mode);
+    localStorage.setItem('palette', palette);
+    localStorage.setItem('mode', mode);
+  }, [palette, mode]);
+
+  const applyTheme = (p, m) => {
     const root = document.documentElement;
-    if (themeValue === 'dark') {
-      root.classList.add('dark');
-    } else {
-      root.classList.remove('dark');
+    root.classList.remove(
+      'palette-ocean',
+      'palette-forest',
+      'palette-sunset',
+      'palette-purple',
+      'dark'
+    );
+    if (p !== 'default') {
+      root.classList.add(`palette-${p}`);
     }
+    if (m === 'dark') {
+      root.classList.add('dark');
+    }
+  };
+
+  const setTheme = (theme) => {
+    if (!AVAILABLE_THEMES.includes(theme)) return;
+    const [p, m] = theme.split('-');
+    if (m) {
+      setPalette(p);
+      setMode(m);
+    } else {
+      setPalette('default');
+      setMode(p);
+    }
+  };
+
+  const toggleMode = () => {
+    setMode((prev) => (prev === 'light' ? 'dark' : 'light'));
   };
 
   const toggleTheme = () => {
-    setTheme((prev) => {
-      const nextTheme = prev === 'light' ? 'dark' : 'light';
-      localStorage.setItem('theme', nextTheme);
-      applyTheme(nextTheme);
-      return nextTheme;
-    });
+    setPalette('default');
+    toggleMode();
   };
 
-  const value = { theme, toggleTheme };
+  const value = {
+    theme: palette === 'default' ? mode : `${palette}-${mode}`,
+    themeInfo: { palette, mode },
+    setTheme,
+    toggleTheme,
+    toggleMode,
+    setPalette,
+    isDark: mode === 'dark',
+    palette
+  };
 
   return (
-    <ThemeContext.Provider value={value}>
-      {children}
-    </ThemeContext.Provider>
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
   );
 }
 

--- a/src/components/atoms/ThemeSelector/ThemeSelector.css
+++ b/src/components/atoms/ThemeSelector/ThemeSelector.css
@@ -1,0 +1,74 @@
+.theme-selector {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-family: var(--font-family-base);
+}
+
+.theme-selector__select {
+  height: var(--component-height-md);
+  padding: var(--component-padding-md);
+  font-size: var(--component-font-md);
+  border: 0.1rem solid var(--border-default);
+  border-radius: var(--radius-md);
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.theme-selector__toggle {
+  height: var(--component-height-md);
+  padding: 0 var(--space-sm);
+  font-size: var(--component-font-md);
+  background-color: var(--color-secondary);
+  color: var(--text-on-primary);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color var(--transition-normal);
+}
+
+.theme-selector__toggle:hover {
+  background-color: var(--color-secondary-hover);
+}
+
+.theme-selector--variant-floating {
+  position: fixed;
+  bottom: var(--space-md);
+  right: var(--space-md);
+  background-color: var(--bg-secondary);
+  padding: var(--space-sm);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: var(--z-tooltip);
+}
+
+.theme-selector--variant-compact .theme-selector__label {
+  display: none;
+}
+
+.theme-selector--size-xs .theme-selector__select,
+.theme-selector--size-xs .theme-selector__toggle {
+  height: var(--component-height-xs);
+  font-size: var(--component-font-xs);
+  padding: var(--space-xs) var(--space-sm);
+}
+
+.theme-selector--size-sm .theme-selector__select,
+.theme-selector--size-sm .theme-selector__toggle {
+  height: var(--component-height-sm);
+  font-size: var(--component-font-sm);
+}
+
+.theme-selector--size-lg .theme-selector__select,
+.theme-selector--size-lg .theme-selector__toggle {
+  height: var(--component-height-lg);
+  font-size: var(--component-font-lg);
+  padding: var(--space-md) var(--space-lg);
+}
+
+.theme-selector--size-xl .theme-selector__select,
+.theme-selector--size-xl .theme-selector__toggle {
+  height: var(--component-height-xl);
+  font-size: var(--component-font-xl);
+  padding: var(--space-md) var(--space-xl);
+}

--- a/src/components/atoms/ThemeSelector/ThemeSelector.jsx
+++ b/src/components/atoms/ThemeSelector/ThemeSelector.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { useTheme } from '../../../app/context/ThemeContext';
+import './ThemeSelector.css';
+
+function ThemeSelector({
+  size = 'md',
+  variant = 'default',
+  showLabels = false,
+  className = '',
+  ...restProps
+}) {
+  const { theme, setTheme, toggleMode, palette } = useTheme();
+
+  const handleChange = (e) => {
+    setTheme(e.target.value);
+  };
+
+  const selectorClasses = [
+    'theme-selector',
+    `theme-selector--size-${size}`,
+    `theme-selector--variant-${variant}`,
+    className
+  ].filter(Boolean).join(' ');
+
+  return (
+    <div className={selectorClasses} {...restProps}>
+      {showLabels && <label className="theme-selector__label">Tema</label>}
+      <select
+        className="theme-selector__select"
+        value={theme}
+        onChange={handleChange}
+        aria-label="Selector de tema"
+      >
+        <optgroup label="Por Defecto">
+          <option value="light">Claro</option>
+          <option value="dark">Oscuro</option>
+        </optgroup>
+        <optgroup label="Océano">
+          <option value="ocean-light">Claro</option>
+          <option value="ocean-dark">Oscuro</option>
+        </optgroup>
+        <optgroup label="Bosque">
+          <option value="forest-light">Claro</option>
+          <option value="forest-dark">Oscuro</option>
+        </optgroup>
+        <optgroup label="Atardecer">
+          <option value="sunset-light">Claro</option>
+          <option value="sunset-dark">Oscuro</option>
+        </optgroup>
+        <optgroup label="Violeta">
+          <option value="purple-light">Claro</option>
+          <option value="purple-dark">Oscuro</option>
+        </optgroup>
+      </select>
+      <button
+        type="button"
+        className="theme-selector__toggle"
+        onClick={toggleMode}
+        aria-label="Alternar modo claro/oscuro"
+      >
+        {palette === 'default' && (theme === 'dark' ? '🌙' : '☀️')}
+        {palette !== 'default' && (theme.endsWith('dark') ? '🌙' : '☀️')}
+      </button>
+    </div>
+  );
+}
+
+export { ThemeSelector };

--- a/src/components/atoms/ThemeSelector/ThemeSelector.stories.jsx
+++ b/src/components/atoms/ThemeSelector/ThemeSelector.stories.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { ThemeSelector } from './ThemeSelector';
+
+export default {
+  title: 'Components/Atoms/ThemeSelector',
+  component: ThemeSelector,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+# ThemeSelector Atom
+
+El átomo **ThemeSelector** permite cambiar entre las paletas y modos disponibles del sistema.
+
+## 🎯 Características principales
+- **5 tamaños**: xs, sm, md, lg, xl
+- **3 variantes**: default, compact, floating
+- **Accesibilidad**: etiquetas ARIA y navegación por teclado
+- **Theming**: Usa variables CSS y contexto de la app
+        `
+      }
+    }
+  },
+  argTypes: {
+    size: {
+      name: 'Tamaño',
+      control: 'select',
+      options: ['xs', 'sm', 'md', 'lg', 'xl']
+    },
+    variant: {
+      name: 'Variante',
+      control: 'select',
+      options: ['default', 'compact', 'floating']
+    },
+    showLabels: {
+      name: 'Mostrar etiquetas',
+      control: 'boolean'
+    }
+  }
+};
+
+export const Default = {
+  args: { size: 'md', variant: 'default', showLabels: true }
+};
+Default.parameters = { docs: { description: { story: 'Configuración por defecto.' } } };
+
+export const Sizes = () => (
+  <div style={{
+    display: 'grid',
+    gap: 'var(--space-lg)',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
+    padding: 'var(--space-md)'
+  }}>
+    <ThemeSelector size="xs" />
+    <ThemeSelector size="sm" />
+    <ThemeSelector size="md" />
+    <ThemeSelector size="lg" />
+    <ThemeSelector size="xl" />
+  </div>
+);
+Sizes.parameters = { docs: { description: { story: 'Los 5 tamaños estándar.' } } };
+
+export const Variants = () => (
+  <div style={{
+    display: 'grid',
+    gap: 'var(--space-lg)',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
+    padding: 'var(--space-md)'
+  }}>
+    <ThemeSelector variant="default" />
+    <ThemeSelector variant="compact" />
+    <ThemeSelector variant="floating" />
+  </div>
+);
+Variants.parameters = { docs: { description: { story: 'Las 3 variantes disponibles.' } } };
+
+export const States = {
+  render: (args) => <ThemeSelector {...args} />,
+  args: { size: 'md' }
+};
+States.parameters = { docs: { description: { story: 'Componente interactivo en su estado normal.' } } };
+
+export const Interactive = {
+  render: () => <ThemeSelector variant="floating" />
+};
+Interactive.parameters = { docs: { description: { story: 'Ejemplo flotante interactivo.' } } };
+
+export const Accessibility = {
+  render: (args) => (
+    <div style={{ padding: 'var(--space-md)' }}>
+      <ThemeSelector {...args} showLabels />
+    </div>
+  ),
+  args: { size: 'md', variant: 'default' }
+};
+Accessibility.parameters = { docs: { description: { story: 'Accesible via teclado y ARIA.' } } };
+

--- a/src/components/atoms/ThemeSelector/index.js
+++ b/src/components/atoms/ThemeSelector/index.js
@@ -1,0 +1,1 @@
+export { ThemeSelector } from './ThemeSelector';

--- a/src/components/organism/AppHeader/AppHeader.jsx
+++ b/src/components/organism/AppHeader/AppHeader.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Button } from '../../atoms/Button/Button';
 import { TextInput } from '../../molecules/TextInput/TextInput';
+import { ThemeSelector } from '../../atoms/ThemeSelector';
 import './AppHeader.css';
 
 /**
@@ -78,6 +79,7 @@ function AppHeader({
         >
           Cerrar Sesión
         </Button>
+        <ThemeSelector variant="compact" size={size === 'lg' ? 'lg' : 'sm'} />
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- extend ThemeContext with palette and mode support
- add color palettes to CSS variables
- create ThemeSelector atom with stories
- embed ThemeSelector in AppHeader

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-storybook')*

------
https://chatgpt.com/codex/tasks/task_e_68648aba3c548330893825b6c05aff51