### PR TITLE
Fix SeriesDetailPage image paths

### DIFF
--- a/src/Pages/SeriesDetailPage/SeriesDetailPage.jsx
+++ b/src/Pages/SeriesDetailPage/SeriesDetailPage.jsx
@@ -157,10 +157,10 @@ function SeriesDetailPage() {
         }
 
         // ✅ FORMATEAR URL DE IMAGEN correctamente
-        const coverUrl = episode.cover_image 
-            ? `http://localhost:8082/covers/${episode.cover_image}`
-            : serie?.cover_image 
-                ? `http://localhost:8082/covers/${serie.cover_image}` 
+        const coverUrl = episode.cover_image
+            ? `http://localhost:8082/covers/${episode.cover_image}/cover.jpg`
+            : serie?.cover_image
+                ? `http://localhost:8082/covers/${serie.cover_image}/cover.jpg`
                 : 'https://via.placeholder.com/300x450?text=Episodio';
 
         const transformedEpisode = {
@@ -231,8 +231,8 @@ function SeriesDetailPage() {
                             alignItems: 'flex-start',
                             flexWrap: 'wrap'
                         }}>
-                            <img 
-                                src={serie.cover_image ? `http://localhost:8082/covers/${serie.cover_image}` : 'https://via.placeholder.com/300x450?text=Serie'}
+                            <img
+                                src={serie.cover_image ? `http://localhost:8082/covers/${serie.cover_image}/cover.jpg` : 'https://via.placeholder.com/300x450?text=Serie'}
                                 alt={`Carátula de ${serie.title}`}
                                 style={{
                                     width: '200px',


### PR DESCRIPTION
## Summary
- fix cover image URLs in `SeriesDetailPage` so episode and series images display correctly

## Testing
- `npm run lint` *(fails: cannot find module 'eslint-plugin-storybook')*

------
https://chatgpt.com/codex/tasks/task_e_68649766f9148330b92c964c4a824669